### PR TITLE
Fix MATCH, VLOOKUP, HLOOKUP search for FALSE

### DIFF
--- a/lib/lookup-reference.js
+++ b/lib/lookup-reference.js
@@ -2,7 +2,7 @@ var error = require('./utils/error');
 var utils = require('./utils/common');
 
 exports.MATCH = function (lookupValue, lookupArray, matchType) {
-  if (!lookupValue && !lookupArray) {
+  if (typeof lookupValue === 'undefined' || lookupValue === null || !lookupArray) {
     return error.na;
   }
 
@@ -63,7 +63,7 @@ exports.MATCH = function (lookupValue, lookupArray, matchType) {
 };
 
 exports.VLOOKUP = function (needle, table, index, rangeLookup) {
-  if (!needle || !table || !index) {
+  if (typeof needle === 'undefined' || needle === null || !table || !index) {
     return error.na;
   }
 
@@ -88,7 +88,7 @@ exports.VLOOKUP = function (needle, table, index, rangeLookup) {
 };
 
 exports.HLOOKUP = function (needle, table, index, rangeLookup) {
-  if (!needle || !table || !index) {
+  if (typeof needle === 'undefined' || needle === null || !table || !index) {
     return error.na;
   }
 


### PR DESCRIPTION
Testing `!needle` returns `error.na` when needle is FALSE, which is a valid search value
Also adapt the test in MATCH to return `error.na` if the value **or** the array is null (previous **and**)